### PR TITLE
docs: README, CLAUDE.md & secret rotation; chore: ignore generated artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: shfmt -d -i 4 -ci ./*.sh
 
       - name: yamllint
-        run: yamllint -c .yamllint.yml kind-config.yaml values.yaml examples/*.yaml
+        run: yamllint -c .yamllint.yml kind-config.yaml values.yaml examples/*.yaml manifests/*.yaml
 
   # Validates a "mock" deployment with no live Sumo org: the upstream sumologic
   # chart is rendered against every values file with dummy credentials (mirroring

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 .DS_Store
 *.tar*
+
+# Rendered manifest from `-o`/--output (default file name; `tee`d into the cwd).
+sumologic-rendered.yaml
+
+# Leftover only if the Homebrew bootstrap fails before install_dependencies'
+# own `rm` runs (the ERR trap would exit first).
+install_homebrew.sh
+
+# Note: the direct-install downloads for jq/kubectl/kind/helm/podman all go to
+# /tmp (then install_binary moves them onto PATH), so they never land in the repo
+# and don't need ignoring here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md
+
+Guidance for working in this repository. See [README.md](README.md) for user-facing
+usage and [CONTRIBUTING.md](CONTRIBUTING.md) for the versioning/commit conventions.
+
+## What this is
+
+A single Bash script, [`sumo-otel-local.sh`](sumo-otel-local.sh), that bootstraps a
+local [KinD](https://kind.sigs.k8s.io/) cluster and installs the Sumo Logic
+OpenTelemetry Collector Helm chart (`sumologic/sumologic`) for local testing. Runs on
+**macOS and Linux**, backed by **Docker or Podman**.
+
+## Repository layout
+
+- `sumo-otel-local.sh` — the entire tool (~930 lines). Everything below lives here.
+- `kind-config.yaml` — 3-node KinD cluster (1 control-plane, 2 workers). The cluster
+  **name is intentionally not set here**; the script owns it via `--name` (default `sumo`).
+- `values.yaml` — default Helm values (used by `-o`/`-m` if present).
+- `examples/` — advanced Helm values files + their `README.md`.
+- `manifests/metrics_auth.yaml` — sample K8s resources for the `metrics_auth` example.
+- `.github/workflows/ci.yml` — lint matrix (Ubuntu+macOS) + `mock-deploy` validation.
+- `.github/workflows/release-please.yml` + `release-please-config.json` +
+  `.release-please-manifest.json` — release automation.
+- `.yamllint.yml` — relaxed yamllint config.
+- `TODO.md` — prioritised backlog with a "Done" section recording completed work.
+
+## Script structure
+
+Top of file: `set -euo pipefail`, an `on_error` ERR trap (reports and exits; it does
+**not** delete anything), platform detection (`OS`, `ARCH`, `JQ_OS`), the
+`SECRET_BACKEND` selection, and the overridable constants (`MIN_MEM_MB`, `MIN_CPU`,
+`CONTAINER_RUNTIME`, `VERSION`, `DEFAULT_CLUSTER_NAME`, `ASSUME_YES`).
+
+Flags are parsed in a `while`/`case` loop at the bottom. Each **action** flag runs its
+flow and `exit`s; `-y`/`--yes`/`--non-interactive` is a **modifier** (sets
+`ASSUME_YES`, then falls through to process the action), so it goes before the action,
+e.g. `-y -i`.
+
+| Flag           | Flow (functions called)                                  |
+| -------------- | -------------------------------------------------------- |
+| `-i/--install` | `install_dependencies` → `init_cluster` → `install_sumo` |
+| `-n/--init`    | `install_dependencies` → `init_cluster`                  |
+| `-m/--helm`    | `install_sumo` (existing cluster)                        |
+| `-o/--output`  | `output` (renders manifests via `helm template`)         |
+| `-u/--uninstall` | `uninstall` (deletes the cluster)                      |
+| `-p/--purge`   | `purge` (cluster + Podman machine on macOS + secrets)    |
+| `-v/--version` | `version` (offline; prints `VERSION`)                    |
+
+Key helper groups:
+
+- **Prompts:** `confirm` (y/n with `[Y/n]`/`[y/N]` hints) and `ask` (value with
+  default). Both honour `ASSUME_YES`. **All interactive prompts must route through
+  these** so unattended mode works.
+- **Runtime:** `select_runtime` (docker/podman, honours `CONTAINER_RUNTIME`),
+  `set_kind_provider` (exports `KIND_EXPERIMENTAL_PROVIDER`), `ensure_podman_ready` /
+  `ensure_docker_ready`, `check_docker_resources` (enforces `MIN_MEM_MB`/`MIN_CPU`),
+  `new_podman` / `use_existing_podman` / `stop_running_machine`, `mem_to_mib`.
+- **Cluster:** `cluster_exists`, `init_cluster` (offers reuse/recreate/cancel if the
+  named cluster exists), `select_node_image` (prompts for a `kindest/node` tag).
+- **Helm:** `ensure_helm_repo` (idempotent `repo add --force-update`),
+  `require_values_file` (values files are **optional**; only validated when used),
+  `yaml_escape`, `install_sumo`, `output`.
+- **Secrets:** `secret_get`/`secret_set`/`secret_delete`/`secret_env_var` over
+  `SECRET_BACKEND` ∈ {`keychain`, `secret-tool`, `env`}. Stored under
+  `sumologic_access_id` / `sumologic_access_key`. Credentials are **never** passed on
+  the Helm CLI — they go in a `chmod 600` temp values file deleted on exit.
+- **Dependencies:** `install_dependencies` (brew on macOS, direct binary downloads on
+  Linux), `install_bin_dir`, `install_binary`, `require_cmd` (fail-fast pre-flight for
+  flows that skip dependency install).
+
+## Hard constraints
+
+- **Bash 3.2 compatible** (macOS ships 3.2). No `declare -A`/associative arrays, no
+  `${var^^}` — use `tr`, indexed arrays, and temp files instead.
+- **`set -euo pipefail`** is in force: guard optional vars with `${var:-}`.
+- **Credentials never on the command line / process list.** Keep the temp-values-file
+  pattern.
+- **Stderr for UI, stdout for results.** Functions whose output is captured with
+  `$(...)` (e.g. `select_node_image`) must send prompts/logs to `>&2`.
+
+## Lint & validate (this is the CI gate)
+
+Run before every commit — CI runs exactly these on an Ubuntu + macOS matrix:
+
+```bash
+bash -n sumo-otel-local.sh                       # syntax
+shellcheck sumo-otel-local.sh                     # lint (must be clean)
+shfmt -d -i 4 -ci sumo-otel-local.sh              # format (4-space indent, switch-case indent)
+yamllint -c .yamllint.yml kind-config.yaml values.yaml examples/*.yaml
+```
+
+`shfmt -w -i 4 -ci sumo-otel-local.sh` rewrites in place.
+
+The **`mock-deploy`** CI job additionally renders the chart against every values file
+with dummy creds + `kubeconform`, then validates server-side on a KinD cluster
+(`helm install --dry-run=server`). No live Sumo org is required.
+
+## How changes are verified
+
+There is no unit-test framework. Behaviour is verified with **stub harnesses**:
+override external commands (`kind`, `helm`, `podman`, `security`, …) as Bash functions
+that record their argv to a temp file, `source` the script (with `set --` first so the
+test's positional args don't reach the arg parser), drive the target function, and
+assert on captured calls. Feed prompt input via here-strings/pipes so `read` sees it.
+
+## Workflow & releases
+
+- Work on **`dev`**; `main` is protected (PRs + **GPG-signed commits** + required
+  checks `Lint (ubuntu-latest)` / `Lint (macos-latest)`; admin bypass). Commit with
+  `git commit -S`. After a squash-merge, reset `dev` onto `main`.
+- **Conventional Commits**, enforced at the **PR title** (squash-merge makes the PR
+  title the commit subject on `main`). `feat:`→MINOR, `fix:`→PATCH; `ci`/`docs`/`chore`
+  /`refactor` don't bump. While `0.x`, breaking changes bump MINOR.
+- `release-please` runs on push to `main`, opens a release PR from the conventional
+  subjects, and on merge tags `vX.Y.Z` + rewrites the `VERSION` line (annotated
+  `# x-release-please-version`). Keep that annotation intact.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,51 @@ chosen automatically:
 - **Fallback** → environment variables `SUMOLOGIC_ACCESS_ID` / `SUMOLOGIC_ACCESS_KEY`
   (nothing is persisted; export them to avoid re-entering).
 
-`-p`/`--purge` removes the stored `sumologic_access_id` / `sumologic_access_key`
-entries. Credentials are never passed on the Helm command line — they're written to a
-private, `chmod 600` temporary values file that is deleted on exit.
+Both entries are named `sumologic_access_id` and `sumologic_access_key`. The install
+flow only prompts when an entry is **not found** — once stored, it is reused silently,
+so to change credentials you must overwrite or delete the stored entry (see below).
+
+Credentials are never passed on the Helm command line — they're written to a private,
+`chmod 600` temporary values file that is deleted on exit.
+
+### Inspecting & rotating credentials
+
+**macOS Keychain** (the same items appear in _Keychain Access.app_):
+
+```bash
+# Inspect
+security find-generic-password -s sumologic_access_id -w
+
+# Rotate in place (-U updates the existing item)
+security add-generic-password -U -a "$USER" -s sumologic_access_id -w 'NEW_ACCESS_ID'
+security add-generic-password -U -a "$USER" -s sumologic_access_key -w 'NEW_ACCESS_KEY'
+
+# …or delete so the next install re-prompts
+security delete-generic-password -s sumologic_access_id
+security delete-generic-password -s sumologic_access_key
+```
+
+**Linux libsecret** (`secret-tool`):
+
+```bash
+# Inspect
+secret-tool lookup service sumologic_access_id
+
+# Rotate (store overwrites the existing entry)
+printf %s 'NEW_ACCESS_ID'  | secret-tool store --label=sumologic_access_id  service sumologic_access_id
+printf %s 'NEW_ACCESS_KEY' | secret-tool store --label=sumologic_access_key service sumologic_access_key
+
+# …or clear so the next install re-prompts
+secret-tool clear service sumologic_access_id
+secret-tool clear service sumologic_access_key
+```
+
+**Environment fallback:** nothing is cached — just re-export `SUMOLOGIC_ACCESS_ID` /
+`SUMOLOGIC_ACCESS_KEY` with the new values.
+
+`-p`/`--purge` also removes both stored entries, but it tears down the cluster (and the
+Podman machine on macOS) too — for a credentials-only change, prefer the per-backend
+commands above.
 
 ## Kubernetes version
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,38 @@
 # sumo-otel-local
 
-Sumo OTEL Collector Local Bootstrapper for MacOS
+Sumo OTEL Collector local bootstrapper for **macOS and Linux**.
 
 ## About
 
-A quick method for testing the Sumo OTEL Collector using a local KinD Cluster. The cluster configuration creates a `3` node cluster which is sufficient for the
-Sumo OTEL Collector to install and for the user to validate configuration settings.
+A quick way to test the Sumo Logic OpenTelemetry Collector on a local
+[KinD](https://kind.sigs.k8s.io/) cluster. The bundled `kind-config.yaml` creates a
+3-node cluster (one control-plane, two workers) — enough to install the collector and
+validate configuration.
 
-## Basic Usage
+It runs on **macOS and Linux** (Intel/`amd64` and Apple Silicon/`arm64`) and supports
+**Docker and Podman** as first-class container runtimes — if both are installed it
+asks which to use; otherwise it uses whichever is present.
 
-Clone this repo and run the script
+## Prerequisites
+
+- **A container runtime: Docker or Podman.** If neither is installed, `--install` /
+  `--init` will offer to install Podman (via Homebrew on macOS, or with guidance on
+  Linux).
+- **macOS:** [Homebrew](https://brew.sh/) — used to install the remaining tools.
+- **Linux:** `curl` and `tar` — the script downloads the remaining tools directly.
+- Remaining CLIs (`kind`, `kubectl`, `helm`, `jq`) are installed for you by
+  `--install` / `--init` if they are missing.
+- A Sumo Logic **Access ID** and **Access Key** (prompted for, or supplied via secret
+  storage / environment — see [Credentials](#credentials--secret-storage)).
+
+> **Resources:** the collector stack is memory-hungry. By default the script expects
+> the runtime/VM to have at least **18 GiB RAM (`18432` MiB) and 4 vCPUs**, and a new
+> Podman machine is created with those defaults. Both are overridable — see
+> [Configuration](#configuration).
+
+## Basic usage
+
+Clone the repo and run the script:
 
 ```bash
 git clone git@github.com:bradtho/sumo-otel-local.git
@@ -18,38 +41,108 @@ chmod +x sumo-otel-local.sh
 ./sumo-otel-local.sh -i
 ```
 
-Follow the in-script prompts.
+Follow the in-script prompts. To tear everything down again, use `-u` (cluster) or
+`-p` (cluster and, with Podman on macOS, the Podman machine).
 
-For additional options use the `help` function
+## Commands
 
-```bash
-./sumo-otel-local.sh -h
+```text
 Usage: ./sumo-otel-local.sh [options]
 Options:
-    -h, --help      Display this help message.
-    -i, --install   Install the dependencies and setup the Sumo Operator.
-    -n, --init      Install dependencies without setting up the Sumo Operator.
-    -m, --helm      Install Sumo Operator onto existing cluster.
-    -o, --output    Output the rendered Kubernetes manifest YAML file.
-    -p, --purge     Uninstall the Cluster and Podman Machine.
-    -u, --uninstall Uninstall the Cluster only.
-    -v, --version   Display the version of the script.
+  -h, --help      Display this help message.
+  -i, --install   Install the dependencies and setup the Sumo Operator.
+  -n, --init      Install dependencies without setting up the Sumo Operator.
+  -m, --helm      Install Sumo Operator onto existing cluster.
+  -o, --output    Output the rendered Kubernetes manifest YAML file.
+  -p, --purge     Uninstall the cluster (and, with Podman on macOS, the Podman machine).
+  -u, --uninstall Uninstall the Cluster only.
+  -v, --version   Display the version of the script.
+  -y, --yes       Run unattended: assume yes and use defaults for all prompts.
+                  (also via the ASSUME_YES env var; --non-interactive is an alias)
 ```
+
+`-y`/`--yes` is a modifier, combine it with an action, e.g. `./sumo-otel-local.sh -y -i`.
+In unattended mode the Sumo credentials **must** come from secret storage or the
+environment (the script will not block on a prompt).
+
+## Configuration
+
+The script reads a few environment variables; all are optional.
+
+- **`CONTAINER_RUNTIME`** (default: _prompt_) — force the runtime: `docker` or
+  `podman`. If unset and both are installed you're prompted; if only one is present
+  it's used automatically.
+- **`MIN_MEM_MB`** (default: `18432`) — minimum memory (MiB) the runtime/VM must have;
+  also the size of a newly-created Podman machine.
+- **`MIN_CPU`** (default: `4`) — minimum vCPUs the runtime/VM must have.
+- **`ASSUME_YES`** (default: _unset_) — any non-empty value runs unattended (same as `-y`).
+- **`SUMOLOGIC_ACCESS_ID`** / **`SUMOLOGIC_ACCESS_KEY`** (default: _unset_) — your Sumo
+  credentials, used when no secret backend is available (see below).
+
+Example — force Docker with a smaller footprint, unattended:
+
+```bash
+CONTAINER_RUNTIME=docker MIN_MEM_MB=8192 MIN_CPU=2 \
+  SUMOLOGIC_ACCESS_ID=xxxx SUMOLOGIC_ACCESS_KEY=yyyy \
+  ./sumo-otel-local.sh -y -i
+```
+
+## Credentials & secret storage
+
+Your Sumo Access ID/Key are stored once and reused on later runs. The backend is
+chosen automatically:
+
+- **macOS** → Keychain (`security`), under the items `sumologic_access_id` and
+  `sumologic_access_key`.
+- **Linux** → libsecret (`secret-tool`), if installed, under the same names.
+- **Fallback** → environment variables `SUMOLOGIC_ACCESS_ID` / `SUMOLOGIC_ACCESS_KEY`
+  (nothing is persisted; export them to avoid re-entering).
+
+`-p`/`--purge` removes the stored `sumologic_access_id` / `sumologic_access_key`
+entries. Credentials are never passed on the Helm command line — they're written to a
+private, `chmod 600` temporary values file that is deleted on exit.
+
+## Kubernetes version
+
+During cluster creation the script fetches the available `kindest/node` image tags and
+lets you pick a Kubernetes version (e.g. `v1.32.2`), or press Enter to use kind's
+default. If the tag list can't be fetched (offline), you can type a version manually.
+
+## Container runtimes
+
+Docker and Podman are both first-class:
+
+- Set `CONTAINER_RUNTIME=docker` or `CONTAINER_RUNTIME=podman` to choose
+  non-interactively, otherwise you're prompted when both are present.
+- On macOS, Podman runs in a VM ("machine"); the script will create/start one sized to
+  `MIN_MEM_MB` / `MIN_CPU` if needed. On Linux, Podman runs natively.
+- KinD is pointed at the selected runtime automatically
+  (`KIND_EXPERIMENTAL_PROVIDER=podman` when Podman is chosen).
 
 ## Advanced (Sandpit)
 
-The `examples` folder contains a curated list of advanced implementation methods. Instructions for these are in the [README](./examples/README.md) file in that folder.
+The `examples` folder contains a curated list of advanced implementation methods.
+Instructions are in the [examples README](./examples/README.md).
+
+You may wish to create a Helm `values.yaml` (pass it when prompted, or via the
+chart's `--set` values) or to amend the `--set`/`--set-string` entries in
+`sumo-otel-local.sh`.
 
 ## Caveat
 
-To run on the Docker/Podman Virtual Machine the `--set sumologic.logs.systemd.enabled=false` had to be set as these systems don't write to the JournalD and will cause the installation to fail.
+On the Docker/Podman VM, `--set sumologic.logs.systemd.enabled=false` is required —
+these environments don't write to journald and the install would otherwise fail. The
+script also sets `sumologic.falco.enabled=false`.
 
-## Editing and Advanced
+## Editing the cluster
 
-Instructions on how to amend the `kind-config.yaml` file are available on the [KinD website](https://kind.sigs.k8s.io/docs/user/configuration/#getting-started)
-
-You may wish to create a Helm Configuration `values.yaml` file or to amend the `--set` and/or `--set-string` entries in the `install.sh` script.
+Instructions for amending `kind-config.yaml` are on the
+[KinD website](https://kind.sigs.k8s.io/docs/user/configuration/#getting-started).
+Note the cluster name is **not** set in that file — `sumo-otel-local.sh` owns it via
+`--name` (default `sumo`).
 
 ## Contributing
 
-This was always intended to be a basic bootstrapping script. However feel free to raise a PR or an issue and I'll get valid ideas incorporated.
+This started as a basic bootstrapping script; PRs and issues are welcome. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the versioning and commit conventions
+(SemVer + Conventional Commits) used to automate releases.

--- a/TODO.md
+++ b/TODO.md
@@ -29,8 +29,6 @@ at the current Bash implementation.
 
 ## P4 — Docs / housekeeping
 
-- [ ] **Document the secret entries** (`sumologic_access_id`/`_key`) per backend
-  (Keychain / secret-tool / env) and how to rotate them.
 - [ ] **`.gitignore` generated artifacts** — the `output` default `sumologic-rendered.yaml`
   and direct-install leftovers (downloaded `kind`/`kubectl`, podman zips). Currently only
   `.DS_Store` and `*.tar*` are ignored.
@@ -43,6 +41,12 @@ at the current Bash implementation.
 
 ### P4 — Docs / housekeeping (complete)
 
+- [x] **Documented the secret entries & rotation** — README's "Credentials & secret
+  storage" now names the `sumologic_access_id` / `sumologic_access_key` entries, notes
+  that stored entries are reused silently (so changing creds needs an overwrite/delete),
+  and gives per-backend inspect/rotate/delete commands for Keychain (`security … -U`),
+  libsecret (`secret-tool store`/`clear`), and the env fallback — plus the caveat that
+  `-p`/`--purge` clears them but also tears down the cluster.
 - [x] **Added `CLAUDE.md`** — repo guidance for future work: layout, the script's
   structure (constants, the flag→flow dispatch table, helper groups), the hard
   constraints (Bash 3.2, `set -euo pipefail`, no-creds-on-CLI, stderr-for-UI), the exact

--- a/TODO.md
+++ b/TODO.md
@@ -29,10 +29,6 @@ at the current Bash implementation.
 
 ## P4 — Docs / housekeeping
 
-- [ ] **Update README** — it still says "for MacOS" and references a non-existent
-  `install.sh` (should be `sumo-otel-local.sh`); document macOS **+ Linux**, both
-  runtimes, the env knobs (`CONTAINER_RUNTIME`, `MIN_MEM_MB`, `MIN_CPU`,
-  `SUMOLOGIC_ACCESS_ID/KEY`), and the new Kubernetes-version prompt.
 - [ ] **Add `CLAUDE.md`** (run `/init`) documenting structure, prerequisites, and the
   install/uninstall flows.
 - [ ] **Document the secret entries** (`sumologic_access_id`/`_key`) per backend
@@ -46,6 +42,15 @@ at the current Bash implementation.
 ---
 
 ## Done
+
+### P4 — Docs / housekeeping (complete)
+
+- [x] **Rewrote README** — now covers macOS **+ Linux** (and `amd64`/`arm64`), fixes the
+  `install.sh` → `sumo-otel-local.sh` references, documents both runtimes, the env knobs
+  (`CONTAINER_RUNTIME`, `MIN_MEM_MB`, `MIN_CPU`, `ASSUME_YES`, `SUMOLOGIC_ACCESS_ID/KEY`),
+  the unattended `-y` mode, the secret backends (Keychain / secret-tool / env), and the
+  `kindest/node` Kubernetes-version prompt. Also partially covers the "document the secret
+  entries" item below (per-backend; rotation still light).
 
 ### P0 — Critical (all complete)
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,6 @@ at the current Bash implementation.
 
 ## P4 — Docs / housekeeping
 
-- [ ] **`.gitignore` generated artifacts** — the `output` default `sumologic-rendered.yaml`
-  and direct-install leftovers (downloaded `kind`/`kubectl`, podman zips). Currently only
-  `.DS_Store` and `*.tar*` are ignored.
 - [ ] **Lint `manifests/*.yaml` too** — CI's yamllint currently covers `kind-config.yaml`,
   `values.yaml`, and `examples/*.yaml` but not `manifests/`.
 
@@ -41,6 +38,12 @@ at the current Bash implementation.
 
 ### P4 — Docs / housekeeping (complete)
 
+- [x] **`.gitignore` generated artifacts** — added `sumologic-rendered.yaml` (the
+  `-o`/--output default, `tee`d into the cwd) and `install_homebrew.sh` (a leftover only
+  if the Homebrew bootstrap fails before its own `rm`). Confirmed via inspection that the
+  jq/kubectl/kind/helm/podman direct-install downloads all go to `/tmp` (then
+  `install_binary` moves them onto PATH), so they never land in the repo — noted in the
+  file instead of adding misleading bare `kind`/`kubectl` ignores.
 - [x] **Documented the secret entries & rotation** — README's "Credentials & secret
   storage" now names the `sumologic_access_id` / `sumologic_access_key` entries, notes
   that stored entries are reused silently (so changing creds needs an overwrite/delete),

--- a/TODO.md
+++ b/TODO.md
@@ -29,8 +29,6 @@ at the current Bash implementation.
 
 ## P4 — Docs / housekeeping
 
-- [ ] **Add `CLAUDE.md`** (run `/init`) documenting structure, prerequisites, and the
-  install/uninstall flows.
 - [ ] **Document the secret entries** (`sumologic_access_id`/`_key`) per backend
   (Keychain / secret-tool / env) and how to rotate them.
 - [ ] **`.gitignore` generated artifacts** — the `output` default `sumologic-rendered.yaml`
@@ -45,6 +43,11 @@ at the current Bash implementation.
 
 ### P4 — Docs / housekeeping (complete)
 
+- [x] **Added `CLAUDE.md`** — repo guidance for future work: layout, the script's
+  structure (constants, the flag→flow dispatch table, helper groups), the hard
+  constraints (Bash 3.2, `set -euo pipefail`, no-creds-on-CLI, stderr-for-UI), the exact
+  lint/validate gate, the stub-harness verification approach, and the `dev`/`main` +
+  signed-commit + Conventional-Commit/release-please workflow.
 - [x] **Rewrote README** — now covers macOS **+ Linux** (and `amd64`/`arm64`), fixes the
   `install.sh` → `sumo-otel-local.sh` references, documents both runtimes, the env knobs
   (`CONTAINER_RUNTIME`, `MIN_MEM_MB`, `MIN_CPU`, `ASSUME_YES`, `SUMOLOGIC_ACCESS_ID/KEY`),

--- a/TODO.md
+++ b/TODO.md
@@ -27,10 +27,7 @@ at the current Bash implementation.
   shelling out to `kubectl`/`helm`/`kind`/`podman`/`docker`; add `pyproject.toml`,
   `pytest`, and extend CI.
 
-## P4 — Docs / housekeeping
-
-- [ ] **Lint `manifests/*.yaml` too** — CI's yamllint currently covers `kind-config.yaml`,
-  `values.yaml`, and `examples/*.yaml` but not `manifests/`.
+_P4 backlog clear — see the Done section below._
 
 ---
 
@@ -38,6 +35,10 @@ at the current Bash implementation.
 
 ### P4 — Docs / housekeeping (complete)
 
+- [x] **Lint `manifests/*.yaml` in CI** — added `manifests/*.yaml` to the yamllint step.
+  The file failed first (trailing spaces, missing final newline, `#comment` spacing), so
+  fixed those; one non-failing `comments-indentation` warning on a commented-out example
+  annotation block remains (fixing it would misrepresent where the annotations sit).
 - [x] **`.gitignore` generated artifacts** — added `sumologic-rendered.yaml` (the
   `-o`/--output default, `tee`d into the cwd) and `install_homebrew.sh` (a leftover only
   if the Homebrew bootstrap fails before its own `rm`). Confirmed via inspection that the

--- a/manifests/metrics_auth.yaml
+++ b/manifests/metrics_auth.yaml
@@ -12,8 +12,8 @@ metadata:
     app: auth-metrics
 type: Opaque
 data:
-  username: cHJvbWV0aGV1cw== #prometheus base64 encoded
-  password: Y2hhbmdlbWU= #changeme base64 encoded
+  username: cHJvbWV0aGV1cw== # prometheus base64 encoded
+  password: Y2hhbmdlbWU= # changeme base64 encoded
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -122,8 +122,8 @@ spec:
   ports:
     - name: http
       port: 8080
-      protocol: TCP       
-      targetPort: 8080 
+      protocol: TCP
+      targetPort: 8080
     - name: metrics1
       port: 8081
       protocol: TCP


### PR DESCRIPTION
Two documentation updates. No script behaviour changes — no version bump.

## README rewrite
The README still described a macOS-only tool and referenced a non-existent `install.sh`. Rewrote it to match the script:
- **macOS + Linux** (`amd64`/`arm64`); **Docker and Podman** both first-class.
- Accurate command table incl. the `-y`/`--yes` **unattended mode**; `install.sh` → `sumo-otel-local.sh` fixed.
- Documents the env knobs (`CONTAINER_RUNTIME`, `MIN_MEM_MB`, `MIN_CPU`, `ASSUME_YES`, `SUMOLOGIC_ACCESS_ID/KEY`), the secret backends (Keychain / secret-tool / env), the `kindest/node` Kubernetes-version prompt, and resource expectations. Links CONTRIBUTING.md.

> Note: this README rewrite was authored earlier but landed just after PR #5 was squash-merged, so it wasn't included there — recovered here.

## CLAUDE.md (new)
Repo guidance for future work: layout, the script's structure (constants/traps, the flag→flow dispatch table, helper groups), the hard constraints (Bash 3.2, `set -euo pipefail`, no-creds-on-CLI, stderr-for-UI), the exact lint/validate gate, the stub-harness verification approach, and the `dev`/`main` + signed-commit + Conventional-Commit/release-please workflow.

## Remaining P4 backlog (tracked in TODO.md)
- Document secret-entry rotation (README covers per-backend; rotation still light)
- `.gitignore` generated artifacts (`sumologic-rendered.yaml`, downloaded binaries)
- Lint `manifests/*.yaml` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)